### PR TITLE
Update Carbon to 2.0.0 to support Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Handesk PHP sdk",
     "type": "library",
     "require": {
-        "nesbot/carbon": "~1.20",
+        "nesbot/carbon": "^2.0.0",
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {


### PR DESCRIPTION
As near as I can see from your source code updating the Carbon version is a very low risk change. 

This change is needed to support Laravel 6. I have tested this locally and have not encountered any issues. 

Could this request be considered? 